### PR TITLE
Build `_site` even if posts or pages are missing

### DIFF
--- a/bin/elmstatic.js
+++ b/bin/elmstatic.js
@@ -308,7 +308,10 @@ function generateFeeds(feedConfig, outputPath, postConfigs) {
 function duplicatePages(config, outputPath) {
     console.log("Duplicating pages...")
     R.forEachObjIndexed((dest, source) => {
-        Fs.copySync(Path.join(outputPath, source), Path.join(outputPath, dest))
+        if (Fs.pathExistsSync(source) && Fs.pathExistsSync(dest)) {
+            Fs.copySync(Path.join(outputPath, source), Path.join(outputPath, dest))
+        }
+        else ; // do nothing
     }, config)
 }
 


### PR DESCRIPTION
I've updated my website to Elm 0.19, but I don't have any posts (cuz I don't have a blog going), and the build breaks when I try to compile it either without the `_posts` folder or with an empty `_posts` folder.

Here is the error message it shows me otherwise:
```
cyberglot.space:master* λ elmstatic
Compiling layouts...
  $ elm make _layouts/Page.elm _layouts/Post.elm _layouts/Posts.elm _layouts/Styles.elm _layouts/Tag.elm --optimize --output elm.js
Success!
Reading .md files...
Cleaning out the output path (_site)...
Generating HTML...
Generating feeds...
  Writing _site/rss.xml
Duplicating pages...
Unhandled rejection Error: ENOENT: no such file or directory, stat '_site/posts'
    at Object.fs.statSync (fs.js:955:11)
    at Object.statSync (/Users/cyberglot/workspace/elmstatic/node_modules/graceful-fs/polyfills.js:295:24)
    at checkStats (/Users/cyberglot/workspace/elmstatic/node_modules/fs-extra/lib/copy-sync/copy-sync.js:171:22)
    at checkPaths (/Users/cyberglot/workspace/elmstatic/node_modules/fs-extra/lib/copy-sync/copy-sync.js:183:31)
    at Object.copySync (/Users/cyberglot/workspace/elmstatic/node_modules/fs-extra/lib/copy-sync/copy-sync.js:25:20)
    at R.forEachObjIndexed (/Users/cyberglot/workspace/elmstatic/bin/elmstatic.js:312:16)
    at forEachObjIndexed (/Users/cyberglot/workspace/elmstatic/node_modules/ramda/src/forEachObjIndexed.js:34:5)
    at Object.f2 [as forEachObjIndexed] (/Users/cyberglot/workspace/elmstatic/node_modules/ramda/src/internal/_curry2.js:29:14)
    at duplicatePages (/Users/cyberglot/workspace/elmstatic/bin/elmstatic.js:310:7)
    at generateHtmlPages.then.then.then.then (/Users/cyberglot/workspace/elmstatic/bin/elmstatic.js:384:21)
    at tryCatcher (/Users/cyberglot/workspace/elmstatic/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/cyberglot/workspace/elmstatic/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/cyberglot/workspace/elmstatic/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/cyberglot/workspace/elmstatic/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/cyberglot/workspace/elmstatic/node_modules/bluebird/js/release/promise.js:693:18)
    at Promise._fulfill (/Users/cyberglot/workspace/elmstatic/node_modules/bluebird/js/release/promise.js:638:18)
```

This pull request fixes this problem.