### PR TITLE
Add support for different feed types

### DIFF
--- a/bin/elmstatic.js
+++ b/bin/elmstatic.js
@@ -428,7 +428,7 @@ function generateEverything(pages, posts, options) {
     R.forEach(writeHtmlPage, tagPages)
 
     log("  Generating feeds")
-    generateFeeds(config.feed, config.outputDir, newPosts)
+    generateFeeds(config.feed, config.outputDir, R.reject(R.propEq("isIndex", true), newPosts))
     log("  Duplicating pages")
     duplicatePages(config.copy, config.outputDir)
     log("  Copying resources")

--- a/bin/elmstatic.js
+++ b/bin/elmstatic.js
@@ -337,20 +337,37 @@ function generateFeed(outputPath, config, posts) {
         })
     }, posts)
 
-    Fs.writeFileSync(outputPath, feed.rss2())
+    let contents;
+
+    switch (config.type) {
+        case "atom":
+            outputPath = Path.join(outputPath, "atom.xml")
+            contents = feed.atom1()
+            break
+
+        case "json":
+            outputPath = Path.join(outputPath, "feed.json")
+            contents = feed.json1()
+            break
+
+        case "rss":
+        default:
+            outputPath = Path.join(outputPath, "rss.xml")
+            contents = feed.rss2()
+    }
+
+    log.info(`    Writing ${outputPath}`)
+    Fs.writeFileSync(outputPath, contents)
 }
 
 // String -> [PostHtmlPage] -> ()/Effects
 function generateFeeds(feedConfig, outputPath, posts) {
     const sections = extractSections(posts)
-    log.info(`    Writing ${Path.join(outputPath, "rss.xml")}`)
-    generateFeed(Path.join(outputPath, "rss.xml"),
-        R.merge(feedConfig, { isSectionFeed: false }), posts)
+    generateFeed(outputPath, R.merge(feedConfig, { isSectionFeed: false }), posts)
 
     R.forEach((section) => {
-        log.info(`    Writing ${Path.join(outputPath, section, "rss.xml")}`)
         generateFeed(
-            Path.join(outputPath, section, "rss.xml"),
+            Path.join(outputPath, section),
             R.evolve({
                 title: R.concat(R.__, `/${section}`),
                 id: R.concat(R.__, `/${section}`),

--- a/scaffold/emu/config.json
+++ b/scaffold/emu/config.json
@@ -5,6 +5,7 @@
         "/posts": "/"
     },
     "feed": {
+        "type": "rss",
         "title": "Author's fancy blog",
         "description": "Author's blog posts",
         "id": "https://example.com",
@@ -12,11 +13,11 @@
         "image": "https://example.com/img/logo.png",
         "copyright": "Copyright: Author",
         "language": "en",
-        "generator": "Elmstatic", 
+        "generator": "Elmstatic",
         "author": {
           "name": "Author",
           "link": "https://example.com/about"
-        }        
+        }
     },
     "tags": ["other", "software"]
 }

--- a/scaffold/md/config.json
+++ b/scaffold/md/config.json
@@ -5,6 +5,7 @@
         "/posts": "/"
     },
     "feed": {
+        "type": "rss",
         "title": "Author's fancy blog",
         "description": "Author's blog posts",
         "id": "https://example.com",
@@ -12,11 +13,11 @@
         "image": "https://example.com/img/logo.png",
         "copyright": "Copyright: Author",
         "language": "en",
-        "generator": "Elmstatic", 
+        "generator": "Elmstatic",
         "author": {
           "name": "Author",
           "link": "https://example.com/about"
-        }        
+        }
     },
     "tags": ["other", "software"]
 }


### PR DESCRIPTION
This PR adds the ability to generate either RSS, Atom, or JSON Feed files based on the `"type"` setting in `config.json`