### PR TITLE
remove generation bottleneck; add custom postprocessing

### DIFF
--- a/bin/elmstatic.js
+++ b/bin/elmstatic.js
@@ -425,7 +425,7 @@ function generateEverything(pages, posts, options) {
         log("  Generating feeds")
         generateFeeds(config.feed, config.outputDir, R.reject(R.propEq("isIndex", true), newPosts))
 
-        if (config.postProcess.length > 0) {
+        if (config.postProcess && config.postProcess.length && config.postProcess.length > 0) {
             log("  Doing your postprocessing")
             config.postProcess.forEach(command => {
                 log(`      ${command}`)


### PR DESCRIPTION
#14 I changed the file writings in the html generation process to be async, this should speed up things a lot...(if not too much, then spawning child processes could be an option). I also created a new config entry where users can add their own post processing commands. Also watch mode does not clean up the output directory anymore, which is I hopefully think, ok.

