### PR TITLE
bump elm-css to 16.1.0

### DIFF
--- a/scaffold/emu/elm.json
+++ b/scaffold/emu/elm.json
@@ -11,10 +11,9 @@
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "mdgriffith/elm-markup": "3.0.1",
-            "rtfeldman/elm-css": "16.0.1"
+            "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {
-            "Skinney/murmur3": "2.0.8",
             "elm/parser": "1.1.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",

--- a/scaffold/md/elm.json
+++ b/scaffold/md/elm.json
@@ -11,14 +11,13 @@
             "elm/html": "1.0.0",
             "elm/json": "1.1.3",
             "elm-explorations/markdown": "1.0.0",
-            "rtfeldman/elm-css": "16.0.1"
+            "rtfeldman/elm-css": "16.1.0"
         },
         "indirect": {
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "rtfeldman/elm-hex": "1.0.0",
-            "Skinney/murmur3": "2.0.8"
+            "rtfeldman/elm-hex": "1.0.0"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
Hi, I tried setting up an elmstatic project with:
`elmstatic init --elm-markup` and `elmstatic build`

But I was facing a dependency issue:

![error](https://user-images.githubusercontent.com/49801232/93671173-1c3c7d80-fa77-11ea-8f36-4cfe5d3f8bef.png)

The main issue seems to be a user that changed username, leading the package to return a 404
https://github.com/robinheghan/murmur3/commit/ec218ceddae5185d01e7eda33f1cb715da045671

To solve that, I found that bumping the elm-css version from `16.0.1` to `16.1.0` would no longer depend on murmur3, resolving the build:
https://package.elm-lang.org/packages/rtfeldman/elm-css/16.0.1/about
https://package.elm-lang.org/packages/rtfeldman/elm-css/16.1.0/about
