### PR TITLE
Fix error occured when generating subsection rss

### DIFF
--- a/bin/elmstatic.js
+++ b/bin/elmstatic.js
@@ -336,8 +336,10 @@ function generateFeeds(feedConfig, outputPath, posts) {
     generateFeed(outputPath, R.mergeRight(feedConfig, { isSectionFeed: false }), posts)
 
     R.forEach((section) => {
+        const sectionPath = Path.join(outputPath, section)
+        Fs.mkdirsSync(sectionPath)
         generateFeed(
-            Path.join(outputPath, section),
+            sectionPath,
             R.evolve({
                 title: R.concat(R.__, `/${section}`),
                 id: R.concat(R.__, `/${section}`),


### PR DESCRIPTION
Hi,
I found a build error when I'm creating subsection `/_posts/foo`.
Generating rss function is failed like below.
So I try to mkdir before generating rss.

```
Error: ENOENT: no such file or directory, open '_site/foo/rss.xml'
    at Object.openSync (node:fs:582:3)
    at Object.writeFileSync (node:fs:2143:35)
    at generateFeed (/Users/youknow/.config/yarn/global/node_modules/elmstatic/bin/elmstatic.js:330:8)
```

maybe you can reproduce with using below one-liner.

```bash
% elmstatic init && mkdir _posts/foo && cat > _posts/foo/2021-07-26-bar.md <<EOS && elmstatic 
---
title: foo-bar
tags: software other
---

# Test
EOS
```
